### PR TITLE
Fix: CVE-2023-45288

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	golang.org/x/crypto v0.25.0 // indirect
+	golang.org/x/crypto v0.31.0// indirect
 	golang.org/x/net v0.27.0 // indirect
 	golang.org/x/oauth2 v0.10.0 // indirect
 	golang.org/x/sys v0.22.0 // indirect


### PR DESCRIPTION
The change will fix CVE-2023-45288

Vulnerability details:  https://nvd.nist.gov/vuln/detail/CVE-2023-45288
Fix: https://github.com/golang/go/issues/70779